### PR TITLE
Remove dependency between auth and keys package

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,0 +1,9 @@
+package auth
+
+import "crypto/rsa"
+
+// RSAPublicKeyCopierRenewer represents the combination of a Copier and Renewer interface
+type RSAPublicKeyCopierRenewer interface {
+	Copy() rsa.PublicKey
+	Renew()
+}

--- a/auth/examples_test.go
+++ b/auth/examples_test.go
@@ -6,14 +6,13 @@ import (
 	"net/http"
 
 	"github.com/LUSHDigital/core/auth"
-	"github.com/LUSHDigital/core/keys"
 
 	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
 )
 
 var (
-	broker keys.RSAPublicKeyCopierRenewer
+	broker auth.RSAPublicKeyCopierRenewer
 )
 
 func ExampleStreamServerInterceptor() {

--- a/auth/grpc.go
+++ b/auth/grpc.go
@@ -3,8 +3,6 @@ package auth
 import (
 	"context"
 
-	"github.com/LUSHDigital/core/keys"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -57,7 +55,7 @@ func (s *authenticatedClientStream) Context() context.Context {
 }
 
 // InterceptServerJWT will check the context metadata for a JWT
-func InterceptServerJWT(ctx context.Context, brk keys.RSAPublicKeyCopierRenewer) (Consumer, error) {
+func InterceptServerJWT(ctx context.Context, brk RSAPublicKeyCopierRenewer) (Consumer, error) {
 	var consumer Consumer
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
@@ -87,7 +85,7 @@ func InterceptServerJWT(ctx context.Context, brk keys.RSAPublicKeyCopierRenewer)
 }
 
 // UnaryServerInterceptor is a gRPC server-side interceptor that checks that JWT provided is valid for unary procedures
-func UnaryServerInterceptor(brk keys.RSAPublicKeyCopierRenewer) func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func UnaryServerInterceptor(brk RSAPublicKeyCopierRenewer) func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		consumer, err := InterceptServerJWT(ctx, brk)
 		if err != nil {
@@ -99,7 +97,7 @@ func UnaryServerInterceptor(brk keys.RSAPublicKeyCopierRenewer) func(ctx context
 }
 
 // StreamServerInterceptor is a gRPC server-side interceptor that checks that JWT provided is valid for streaming procedures
-func StreamServerInterceptor(brk keys.RSAPublicKeyCopierRenewer) func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func StreamServerInterceptor(brk RSAPublicKeyCopierRenewer) func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		consumer, err := InterceptServerJWT(ss.Context(), brk)
 		if err != nil {

--- a/auth/grpc_test.go
+++ b/auth/grpc_test.go
@@ -5,17 +5,14 @@ import (
 	"testing"
 
 	"google.golang.org/grpc"
-
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-
 	"google.golang.org/grpc/status"
 
-	"google.golang.org/grpc/codes"
-
-	"github.com/LUSHDigital/core/keys"
 	jwt "github.com/dgrijalva/jwt-go"
 
 	"github.com/LUSHDigital/core/auth"
+	"github.com/LUSHDigital/core/keys/keysmock"
 )
 
 func TestGRPCMiddleware(t *testing.T) {
@@ -24,7 +21,7 @@ func TestGRPCMiddleware(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	brk := keys.MockRSAPublicKey(*pk)
+	brk := keysmock.MockRSAPublicKey(*pk)
 	grpc.StreamInterceptor(auth.StreamServerInterceptor(brk))
 	grpc.UnaryInterceptor(auth.UnaryServerInterceptor(brk))
 
@@ -93,7 +90,7 @@ func TestInterceptServerJWT(t *testing.T) {
 				md.Set("auth-token", c.jwt)
 			}
 			ctx := metadata.NewIncomingContext(context.Background(), md)
-			brk := keys.MockRSAPublicKey(*pk)
+			brk := keysmock.MockRSAPublicKey(*pk)
 			_, err = auth.InterceptServerJWT(ctx, brk)
 			if c.errors {
 				s, ok := status.FromError(err)

--- a/auth/http.go
+++ b/auth/http.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/LUSHDigital/core/keys"
 	"github.com/LUSHDigital/core/response"
 )
 
@@ -15,7 +14,7 @@ const (
 )
 
 // HandlerValidateJWT takes a JWT from the request headers, attempts validation and returns a http handler.
-func HandlerValidateJWT(brk keys.RSAPublicKeyCopierRenewer, next http.HandlerFunc) http.HandlerFunc {
+func HandlerValidateJWT(brk RSAPublicKeyCopierRenewer, next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw := strings.TrimPrefix(r.Header.Get(authHeader), authHeaderPrefix)
 		pk := brk.Copy()

--- a/auth/http_test.go
+++ b/auth/http_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/LUSHDigital/core/keys"
-
 	"github.com/LUSHDigital/core/auth"
+	"github.com/LUSHDigital/core/keys/keysmock"
 	"github.com/LUSHDigital/core/response"
 	jwt "github.com/dgrijalva/jwt-go"
 )
@@ -22,14 +21,14 @@ func TestHandlerValidateJWT(t *testing.T) {
 
 	cases := []struct {
 		name                 string
-		broker               keys.RSAPublicKeyCopierRenewer
+		broker               auth.RSAPublicKeyCopierRenewer
 		claims               auth.Claims
 		expectedStatusCode   int
 		expectedErrorMessage string
 	}{
 		{
 			name:   "token is good",
-			broker: keys.MockRSAPublicKey(*correctPK),
+			broker: keysmock.MockRSAPublicKey(*correctPK),
 			claims: auth.Claims{
 				StandardClaims: jwt.StandardClaims{
 					IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
@@ -43,7 +42,7 @@ func TestHandlerValidateJWT(t *testing.T) {
 		},
 		{
 			name:   "token has expired",
-			broker: keys.MockRSAPublicKey(*correctPK),
+			broker: keysmock.MockRSAPublicKey(*correctPK),
 			claims: auth.Claims{
 				StandardClaims: jwt.StandardClaims{
 					IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
@@ -57,7 +56,7 @@ func TestHandlerValidateJWT(t *testing.T) {
 		},
 		{
 			name:   "token is not ready yet",
-			broker: keys.MockRSAPublicKey(*correctPK),
+			broker: keysmock.MockRSAPublicKey(*correctPK),
 			claims: auth.Claims{
 				StandardClaims: jwt.StandardClaims{
 					IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),
@@ -71,7 +70,7 @@ func TestHandlerValidateJWT(t *testing.T) {
 		},
 		{
 			name:   "issuedAt is in the future",
-			broker: keys.MockRSAPublicKey(*correctPK),
+			broker: keysmock.MockRSAPublicKey(*correctPK),
 			claims: auth.Claims{
 				StandardClaims: jwt.StandardClaims{
 					IssuedAt:  time.Now().Add(1 * time.Hour).Unix(),
@@ -85,7 +84,7 @@ func TestHandlerValidateJWT(t *testing.T) {
 		},
 		{
 			name:   "token not signed with matching key",
-			broker: keys.MockRSAPublicKey(*incorrectPK),
+			broker: keysmock.MockRSAPublicKey(*incorrectPK),
 			claims: auth.Claims{
 				StandardClaims: jwt.StandardClaims{
 					IssuedAt:  time.Now().Add(-2 * time.Hour).Unix(),

--- a/keys/broker_test.go
+++ b/keys/broker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/LUSHDigital/core/keys"
+	"github.com/LUSHDigital/core/keys/keysmock"
 	"github.com/dgrijalva/jwt-go"
 )
 
@@ -33,7 +34,7 @@ func Test_MockRSAPublicKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	public := private.PublicKey
-	mock := keys.MockRSAPublicKey(public)
+	mock := keysmock.MockRSAPublicKey(public)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,13 +51,15 @@ func Test_BrokerRSAPublicKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b1, c1 := keys.BrokerRSAPublicKey(ctx, source, tick)
-	defer c1()
+	b1 := keys.BrokerRSAPublicKey(ctx, source, tick)
+	defer b1.Close()
+
 	time.Sleep(10 * time.Millisecond)
 	deepEqual(t, *pk, b1.Copy())
 
-	b2, c2 := keys.BrokerRSAPublicKey(ctx, &badSource{}, tick)
-	defer c2()
+	b2 := keys.BrokerRSAPublicKey(ctx, &badSource{}, tick)
+	defer b2.Close()
+
 	time.Sleep(10 * time.Millisecond)
 	deepEqual(t, *keys.DefaultRSA, b2.Copy())
 }

--- a/keys/keysmock/keysmock.go
+++ b/keys/keysmock/keysmock.go
@@ -1,0 +1,30 @@
+package keysmock
+
+import "crypto/rsa"
+
+// MockRSAPublicKey resolves any source and returns a mocked RSAPublicKeyCopier and Renewer
+func MockRSAPublicKey(key rsa.PublicKey) *RSAPublicKeyMock {
+	return &RSAPublicKeyMock{
+		key: &key,
+	}
+}
+
+// RSAPublicKeyMock defines the implementation for brokering an RSA public key during testing
+type RSAPublicKeyMock struct {
+	key *rsa.PublicKey
+}
+
+// Copy returns a shallow copy o the RSA public key
+func (b *RSAPublicKeyMock) Copy() rsa.PublicKey {
+	return *b.key
+}
+
+// Renew is a no-op
+func (b *RSAPublicKeyMock) Renew() {
+	// no-op
+}
+
+// Close is a no-op
+func (b *RSAPublicKeyMock) Close() {
+	// no-op
+}


### PR DESCRIPTION
We define the interface for copier renewer where its being used in the auth package so that any structure can satisfy its needs without being dependent on the keys package.

The keys package instead returns a struct from its broker function with an additional method for deferring a close on the broker in favour of the extra return value.

As a result of this the mock had to move out to a separate package, which overall cleaned up the rest of the keys broker code.