### PR TITLE
Provide readiness server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ These packages contain convenient service workers things like network servers, b
 
 - [core/workers/grpcsrv](https://github.com/LUSHDigital/core/tree/master/workers/grpcsrv#grpc-server)
 - [core/workers/httpsrv](https://github.com/LUSHDigital/core/tree/master/workers/httpsrv#http-server)
+- [core/workers/readysrv](https://github.com/LUSHDigital/core/tree/master/workers/readysrv#ready-server)
 - [core/workers/metricsrv](https://github.com/LUSHDigital/core/tree/master/workers/metricsrv#metric-server)
 - [core/workers/keybroker](https://github.com/LUSHDigital/core/tree/master/workers/keybroker#key-broker)

--- a/workers/readysrv/README.md
+++ b/workers/readysrv/README.md
@@ -1,0 +1,22 @@
+# Ready Server
+The package `core/workers/readysrv` is used to provide readiness checks for a service.
+
+## Configuration
+The readiness server can be configured through the environment to match setup in the infrastructure.
+
+- `READINESS_INTERFACE` default: `:3674`
+- `READINESS_PATH` default: `/ready`
+
+## Examples
+
+```go
+srv := readysrv.New(readysrv.Checks{
+    "google": readysrv.CheckerFunc(func() ([]string, bool) {
+        if _, err := http.Get("https://google.com"); err != nil {
+            return []string{err.Error()}, false
+        }
+        return []string{"google can be accessed"}, true
+    }),
+})
+srv.Run(ctx, ioutil.Discard)
+```

--- a/workers/readysrv/check.go
+++ b/workers/readysrv/check.go
@@ -1,0 +1,22 @@
+package readysrv
+
+// Checks defines a matrix of health checks to be run.
+type Checks map[string]Checker
+
+// AddCheck will add a health check to the matrix.
+func (c Checks) AddCheck(name string, check Checker) {
+	c[name] = check
+}
+
+// Checker defines the interface for checking health of remote services.
+type Checker interface {
+	Check() ([]string, bool)
+}
+
+// CheckerFunc defines a single function for checking health of remote services.
+type CheckerFunc func() ([]string, bool)
+
+// Check will perform the check of the checker function.
+func (f CheckerFunc) Check() ([]string, bool) {
+	return f()
+}

--- a/workers/readysrv/readysrv.go
+++ b/workers/readysrv/readysrv.go
@@ -1,0 +1,86 @@
+// Package readysrv is used to provide readiness checks for a service.
+package readysrv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const (
+	// DefaultInterface is the port that we listen to the prometheus path on by default.
+	DefaultInterface = "0.0.0.0:3674"
+
+	// DefaultPath is the path where we expose prometheus by default.
+	DefaultPath = "/ready"
+)
+
+// New creates a new default metrics server.
+func New(checks Checks) *Server {
+	return &Server{
+		Interface: DefaultInterface,
+		Path:      DefaultPath,
+		Checks:    checks,
+	}
+}
+
+// Server defines a readiness server.
+type Server struct {
+	Interface string
+	Path      string
+	Checks    Checks
+}
+
+// Run will start the metrics server.
+func (s *Server) Run(ctx context.Context, out io.Writer) error {
+	addr := os.Getenv("READINESS_INTERFACE")
+	if addr == "" {
+		addr = DefaultInterface
+	}
+	path := os.Getenv("READINESS_PATH")
+	if path == "" {
+		path = DefaultPath
+	}
+	fmt.Fprintf(out, "serving readiness checks server over http on %s%s", s.Interface, s.Path)
+	http.Handle(path, CheckHandler(s.Checks))
+	return http.ListenAndServe(addr, nil)
+
+}
+
+// CheckHandler provides a function for providing health checks over http.
+func CheckHandler(checks Checks) http.HandlerFunc {
+	type health struct {
+		OK       bool     `json:"ok"`
+		Messages []string `json:"messages"`
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		var ready = true
+		res := make(map[string]health)
+		for name, check := range checks {
+			messages, ok := check.Check()
+			if !ok {
+				ready = false
+			}
+			res[name] = health{
+				OK:       ok,
+				Messages: messages,
+			}
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		bts, err := json.Marshal(res)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		code := http.StatusOK
+		if !ready {
+			code = http.StatusInternalServerError
+		}
+		w.WriteHeader(code)
+		w.Write(bts)
+	}
+}

--- a/workers/readysrv/readysrv_test.go
+++ b/workers/readysrv/readysrv_test.go
@@ -1,0 +1,85 @@
+package readysrv_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/LUSHDigital/core/workers/readysrv"
+)
+
+var (
+	ctx context.Context
+)
+
+func Example() {
+	srv := readysrv.New(readysrv.Checks{
+		"google": readysrv.CheckerFunc(func() ([]string, bool) {
+			if _, err := http.Get("https://google.com"); err != nil {
+				return []string{err.Error()}, false
+			}
+			return []string{"google can be accessed"}, true
+		}),
+	})
+	srv.Run(ctx, ioutil.Discard)
+}
+
+func TestCheckerFunc(t *testing.T) {
+	yes := readysrv.CheckerFunc(func() ([]string, bool) { return []string{}, true })
+	no := readysrv.CheckerFunc(func() ([]string, bool) { return []string{}, false })
+
+	cases := []struct {
+		name     string
+		checks   readysrv.Checks
+		expected int
+	}{
+		{
+			name: "all ok",
+			checks: readysrv.Checks{
+				"a": yes,
+				"b": yes,
+			},
+			expected: 200,
+		},
+		{
+			name: "all ok",
+			checks: readysrv.Checks{
+				"a": yes,
+				"b": no,
+			},
+			expected: 500,
+		},
+		{
+			name: "all ok",
+			checks: readysrv.Checks{
+				"a": no,
+				"b": no,
+			},
+			expected: 500,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rr := httptest.NewRecorder()
+
+			handler := readysrv.CheckHandler(c.checks)
+			handler.ServeHTTP(rr, req)
+
+			equals(t, c.expected, rr.Code)
+		})
+	}
+}
+
+func equals(tb testing.TB, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		tb.Fatalf("\n\texp: %#[1]v (%[1]T)\n\tgot: %#[2]v (%[2]T)\n", expected, actual)
+	}
+}


### PR DESCRIPTION
# Ready Server
The package `core/workers/readysrv` is used to provide readiness checks for a service.

## Configuration
The readiness server can be configured through the environment to match setup in the infrastructure.

- `READINESS_INTERFACE` default: `:3674`
- `READINESS_PATH` default: `/ready`

## Examples

```go
srv := readysrv.New(readysrv.Checks{
    "google": readysrv.CheckerFunc(func() ([]string, bool) {
        if _, err := http.Get("https://google.com"); err != nil {
            return []string{err.Error()}, false
        }
        return []string{"google can be accessed"}, true
    }),
})
srv.Run(ctx, ioutil.Discard)
```