### PR TITLE
Provide cleaner api of httpsrv

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ func main() {
 		"public_key": broker,
 	})
 
-	server := httpsrv.New(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(200)
-		w.Write([]byte("hello world"))
-	}), &http.Server{
+	server := httpsrv.New(&http.Server{
 		ReadTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("hello world"))
+		}),
 	})
 
 	ctx := context.Background()

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -21,11 +21,12 @@ func main() {
 		"public_key": broker,
 	})
 
-	server := httpsrv.New(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(200)
-		w.Write([]byte("hello world"))
-	}), &http.Server{
+	server := httpsrv.New(&http.Server{
 		ReadTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("hello world"))
+		}),
 	})
 
 	ctx := context.Background()

--- a/service_test.go
+++ b/service_test.go
@@ -24,7 +24,7 @@ func ExampleService_StartWorkers() {
 	svc := core.NewService()
 	svc.StartWorkers(ctx,
 		grpcsrv.New(nil),
-		httpsrv.New(handler, nil),
+		httpsrv.NewDefault(handler),
 		metricsrv.New(),
 		keybroker.NewRSA(nil),
 	)

--- a/workers/httpsrv/README.md
+++ b/workers/httpsrv/README.md
@@ -3,17 +3,18 @@ The package `core/workers/httpsrv` provides a default set of configuration for h
 
 ## Examples
 
-### Starting server and expose the service
+### Starting default server and expose the service
 
 ```go
-srv := httpsrv.New(handler)
+srv := httpsrv.NewDefault(handler)
 srv.Run(ctx, os.Stdout)
 ```
 
 ### Starting server with a custom http server
 
 ```
-srv := httpsrv.New(handler, &http.Server{
+srv := httpsrv.New&http.Server{
+    Handler: Handler,
     ReadTimeout: 1 * time.Second,
 })
 srv.Run(ctx, os.Stdout)

--- a/workers/httpsrv/httpsrv_test.go
+++ b/workers/httpsrv/httpsrv_test.go
@@ -31,10 +31,8 @@ func TestMain(m *testing.M) {
 }
 
 func Example() {
-	go httpsrv.New(handler, nil).Run(ctx, os.Stdout)
-
-	// Start a new server worker with a custom http.Server
-	go httpsrv.New(handler, &http.Server{
+	go httpsrv.New(&http.Server{
+		Handler:     handler,
 		ReadTimeout: 1 * time.Second,
 	}).Run(ctx, os.Stdout)
 }


### PR DESCRIPTION
# HTTP Server
The package `core/workers/httpsrv` provides a default set of configuration for hosting a http server in a service.

## Examples

### Starting default server and expose the service

```go
srv := httpsrv.NewDefault(handler)
srv.Run(ctx, os.Stdout)
```

### Starting server with a custom http server

```
srv := httpsrv.New&http.Server{
    Handler: Handler,
    ReadTimeout: 1 * time.Second,
})
srv.Run(ctx, os.Stdout)
```
