### PR TITLE
Load both .env and local.env

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -25,7 +25,7 @@ func MustGet(name string) string {
 
 // TryLoadDefault will attempt to load the default environment variables.
 func TryLoadDefault(paths ...string) {
-	paths = append([]string{"infra/.env"}, paths...)
+	paths = append([]string{"infra/.env", "infra/local.env"}, paths...)
 	if err := godotenv.Load(paths...); err != nil {
 		log.Printf("could not load environment files: %s: skipping...\n", strings.Join(paths, " "))
 	}


### PR DESCRIPTION
The reason for doing this is so that we can have default values in one file that we commit to our source tree and the other one being ignored so it can be overridden in the local environment depending on circumstance.

Since we use the ruby port of dotenv, we might as well also use their `local.env` convention.