### PR TITLE
Variable default locale

### DIFF
--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,4 +1,5 @@
 # Internationalisation
+
 The `core/i18n` package functions for dealing with internationalisation of services.
 
 ## Examples
@@ -12,6 +13,7 @@ fmt.Println(locale)
 ```
 
 ### Put locale through context
+
 Setting the locale in a context.
 
 ```go
@@ -22,4 +24,16 @@ Retreiving a locale from context.
 
 ```go
 locale = i18n.LocaleFromContext(ctx)
+```
+
+### Change the default locale
+
+You can set the default locale to be any value you'd like. By default it's set to `en`.
+
+```go
+import "github.com/LUSHDigital/core/i18n"
+
+func main() {
+    i18n.DefaultLocale = "es"
+}
 ```

--- a/i18n/context.go
+++ b/i18n/context.go
@@ -20,5 +20,5 @@ func LocaleFromContext(ctx context.Context) string {
 	if c, ok := ctx.Value(localeKey).(string); ok {
 		return c
 	}
-	return DefaultLanguage
+	return DefaultLocale
 }

--- a/i18n/context_test.go
+++ b/i18n/context_test.go
@@ -25,6 +25,10 @@ func TestContext(t *testing.T) {
 	ctx = i18n.ContextWithLocale(context.Background(), "sv")
 	locale = i18n.LocaleFromContext(ctx)
 	test.Equals(t, "sv", locale)
+	i18n.DefaultLocale = "es"
+	locale = i18n.LocaleFromContext(context.Background())
+	test.Equals(t, "es", locale)
+	i18n.DefaultLocale = "en"
 	locale = i18n.LocaleFromContext(context.Background())
 	test.Equals(t, "en", locale)
 }

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -4,9 +4,9 @@ import (
 	"golang.org/x/text/language"
 )
 
-const (
-	// DefaultLanguage is the default locale is set to english for simplicity.
-	DefaultLanguage = "en"
+var (
+	// DefaultLocale is the default locale is set to english for simplicity.
+	DefaultLocale = "en"
 )
 
 // ParseLocale will attempt to read the locale from a string.

--- a/middleware/i18nmw/grpc.go
+++ b/middleware/i18nmw/grpc.go
@@ -41,7 +41,7 @@ func InterceptLocale(ctx context.Context) (string, error) {
 		}
 	}
 	if locale == "" {
-		locale = i18n.DefaultLanguage
+		locale = i18n.DefaultLocale
 	}
 	return locale, nil
 }

--- a/middleware/i18nmw/http.go
+++ b/middleware/i18nmw/http.go
@@ -26,7 +26,7 @@ func ParseLocaleHandler(next http.HandlerFunc) http.HandlerFunc {
 			}
 		}
 		if locale == "" {
-			locale = i18n.DefaultLanguage
+			locale = i18n.DefaultLocale
 		}
 		ctx := i18n.ContextWithLocale(r.Context(), locale)
 		next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
### Change the default locale

You can set the default locale to be any value you'd like. By default it's set to `en`.

```go
import "github.com/LUSHDigital/core/i18n"

func main() {
    i18n.DefaultLocale = "es"
}
```
