### PR TITLE
New service worker API, including graceful termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ func main() {
 		}),
 	})
 
-	service.StartWorkers(context.Background(),
+	service.MustRun(context.Background(),
 		server,
 		metrics,
 		broker,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ These packages contain functionality for the core concepts of our services.
 - [core/pagination](https://github.com/LUSHDigital/core/tree/master/pagination#pagination)
 - [core/rest](https://github.com/LUSHDigital/core/tree/master/rest#rest)
 - [core/test](https://github.com/LUSHDigital/core/tree/master/test#test)
+- [core/workers](https://github.com/LUSHDigital/core/tree/master/workers#workers)
 
 ### Middlewares
 These packages contain convenient middlewares for transport protocols like HTTP REST and gRPC.
@@ -74,8 +75,8 @@ These packages contain convenient middlewares for transport protocols like HTTP 
 - [core/middleware/paginationmw](https://github.com/LUSHDigital/core/tree/master/middleware/paginationmw#pagination-middleware)
 - [core/middleware/tracingmw](https://github.com/LUSHDigital/core/tree/master/middleware/tracingmw#tracing-middleware)
 
-### Service Workers
-These packages contain convenient service workers things like network servers, background workers and message brokers.
+### Workers
+These packages contain convenient workers things like network servers, background workers and message brokers.
 
 - [core/workers/grpcsrv](https://github.com/LUSHDigital/core/tree/master/workers/grpcsrv#grpc-server)
 - [core/workers/httpsrv](https://github.com/LUSHDigital/core/tree/master/workers/httpsrv#http-server)

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -22,9 +22,9 @@ func main() {
 	core.SetupLogs()
 
 	metrics := metricsrv.New(nil)
-	broker := keybroker.NewRSA(nil)
-	readiness := readysrv.New(readysrv.Checks{
-		"rsa_key": broker,
+	broker := keybroker.NewPublicRSA(nil)
+	readiness := readysrv.New(nil, readysrv.Checks{
+		"public_rsa_key": broker,
 	})
 
 	server := httpsrv.New(&http.Server{
@@ -35,7 +35,7 @@ func main() {
 		}),
 	})
 
-	service.StartWorkers(context.Background(),
+	service.MustRun(context.Background(),
 		server,
 		metrics,
 		broker,

--- a/service.go
+++ b/service.go
@@ -133,7 +133,7 @@ func (s *Service) grace() time.Duration {
 	return grace
 }
 
-// WaitWithTimeout defines
+// WaitWithTimeout will wait for a number of pieces of work has finished and send a message on the completed channel.
 func WaitWithTimeout(delta int, cancelled <-chan int, timeout time.Duration) (<-chan int, func()) {
 	completed := make(chan int, 1)
 	wg := &sync.WaitGroup{}

--- a/service.go
+++ b/service.go
@@ -58,7 +58,7 @@ func NewService(name, kind string, opts ...ServiceOption) *Service {
 // ServiceWorker represents the behaviour for running a service worker.
 type ServiceWorker interface {
 	// Run should be a blocking operation
-	Run(context.Context, io.Writer) error
+	Run(context.Context) error
 }
 
 type writer func(b []byte) (int, error)

--- a/service_test.go
+++ b/service_test.go
@@ -22,7 +22,7 @@ func ExampleNewService() {
 
 func ExampleService_StartWorkers() {
 	service := core.NewService("example", "service")
-	service.StartWorkers(ctx,
+	service.MustRun(ctx,
 		grpcsrv.New(nil),
 		httpsrv.NewDefault(handler),
 		metricsrv.New(nil),

--- a/workers/README.md
+++ b/workers/README.md
@@ -1,0 +1,27 @@
+# Workers
+The `core/workers` package is used to setup gracefully terminating workers for services.
+
+## Examples
+
+### The worker interfaces
+All workers implement a simple interface for running and halting, using the context package for timeouts.
+
+```go
+// Runner represents the behaviour for running a service worker.
+type Runner interface {
+	// Run should run start processing the worker and be a blocking operation.
+	Run(context.Context) error
+}
+
+// Halter represents the behaviour for stopping a service worker.
+type Halter interface {
+	// Halt should tell the worker to stop doing work.
+	Halt(context.Context) error
+}
+
+// Worker represents the behaviour for a service worker.
+type Worker interface {
+	Runner
+	Halter
+}
+```

--- a/workers/doc.go
+++ b/workers/doc.go
@@ -1,0 +1,2 @@
+// Package workers is used to setup gracefully terminating workers for services.
+package workers

--- a/workers/grpcsrv/README.md
+++ b/workers/grpcsrv/README.md
@@ -17,5 +17,5 @@ srv := grpcsrv.New(&grpcsrv.Config{
     grpc.StreamInterceptor(paginationmw.StreamServerInterceptor),
     grpc.UnaryInterceptor(paginationmw.UnaryServerInterceptor),
 )
-srv.Run(ctx, ioutil.Discard)
+srv.Run(ctx)
 ```

--- a/workers/grpcsrv/grpcsrv.go
+++ b/workers/grpcsrv/grpcsrv.go
@@ -68,6 +68,13 @@ func (gs *Server) Run(ctx context.Context) error {
 	return gs.Connection.Serve(lis)
 }
 
+// Halt will attempt to gracefully shut down the server.
+func (gs *Server) Halt(ctx context.Context) error {
+	log.Printf("stopping serving grpc on %s...", gs.Addr().String())
+	gs.Connection.GracefulStop()
+	return nil
+}
+
 // Addr will block until you have received an address for your server.
 func (gs *Server) Addr() *net.TCPAddr {
 	if gs.tcpAddr != nil {

--- a/workers/grpcsrv/grpcsrv.go
+++ b/workers/grpcsrv/grpcsrv.go
@@ -3,8 +3,7 @@ package grpcsrv
 
 import (
 	"context"
-	"fmt"
-	"io"
+	"log"
 	"net"
 	"os"
 	"strconv"
@@ -55,7 +54,7 @@ type Server struct {
 }
 
 // Run will start the gRPC server and listen for requests.
-func (gs *Server) Run(ctx context.Context, out io.Writer) error {
+func (gs *Server) Run(ctx context.Context) error {
 	lis, err := net.Listen("tcp", gs.addr)
 	if err != nil {
 		return err
@@ -65,7 +64,7 @@ func (gs *Server) Run(ctx context.Context, out io.Writer) error {
 	hsrv := health.NewServer()
 	grpc_health_v1.RegisterHealthServer(gs.Connection, hsrv)
 
-	fmt.Fprintf(out, "serving grpc on %s", gs.Addr().String())
+	log.Printf("serving grpc on %s", gs.Addr().String())
 	return gs.Connection.Serve(lis)
 }
 

--- a/workers/grpcsrv/grpcsrv_test.go
+++ b/workers/grpcsrv/grpcsrv_test.go
@@ -5,7 +5,6 @@ package grpcsrv_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -41,7 +40,7 @@ func TestHealthCheck(t *testing.T) {
 	server := grpcsrv.New(&grpcsrv.Config{
 		Addr: "",
 	})
-	go server.Run(ctx, ioutil.Discard)
+	go server.Run(ctx)
 	addr := server.Addr()
 	host := fmt.Sprintf("127.0.0.1:%d", addr.Port)
 	conn, err := grpc.Dial(host, grpc.WithInsecure())
@@ -65,7 +64,7 @@ func Example() {
 		grpc.StreamInterceptor(paginationmw.StreamServerInterceptor),
 		grpc.UnaryInterceptor(paginationmw.UnaryServerInterceptor),
 	)
-	srv.Run(ctx, ioutil.Discard)
+	srv.Run(ctx)
 }
 
 func TestServer_Addr(t *testing.T) {
@@ -76,7 +75,7 @@ func TestServer_Addr(t *testing.T) {
 			Addr: ":",
 		})
 		servers[i] = srv
-		go srv.Run(ctx, ioutil.Discard)
+		go srv.Run(ctx)
 	}
 	for _, srv := range servers {
 		test.NotEquals(t, ":0", srv.Addr().String())

--- a/workers/httpsrv/README.md
+++ b/workers/httpsrv/README.md
@@ -17,10 +17,10 @@ srv.Run(ctx, os.Stdout)
 
 ### Starting server with a custom http server
 
-```
-srv := httpsrv.New&http.Server{
+```go
+srv := httpsrv.New(&http.Server{
     Handler: Handler,
     ReadTimeout: 1 * time.Second,
 })
-srv.Run(ctx, os.Stdout)
+srv.Run(ctx)
 ```

--- a/workers/httpsrv/httpsrv.go
+++ b/workers/httpsrv/httpsrv.go
@@ -4,7 +4,7 @@ package httpsrv
 import (
 	"context"
 	"fmt"
-	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -129,7 +129,7 @@ type Server struct {
 }
 
 // Run will start the gRPC server and listen for requests.
-func (gs *Server) Run(ctx context.Context, out io.Writer) error {
+func (gs *Server) Run(ctx context.Context) error {
 	addr := gs.Server.Addr
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -142,7 +142,7 @@ func (gs *Server) Run(ctx context.Context, out io.Writer) error {
 	}
 
 	gs.Server.Handler = WrapperHandler(gs.Now, gs.Server.Handler)
-	fmt.Fprintf(out, "serving http on http://%s", gs.Addr().String())
+	log.Printf("serving http on http://%s", gs.Addr().String())
 	return gs.Server.Serve(lis)
 }
 

--- a/workers/httpsrv/httpsrv.go
+++ b/workers/httpsrv/httpsrv.go
@@ -92,7 +92,7 @@ func NewDefault(handler http.Handler) *Server {
 // New sets up a new HTTP server.
 func New(server *http.Server) *Server {
 	if server == nil {
-		server = &http.Server{}
+		server = &DefaultHTTPServer
 	}
 	if server.WriteTimeout == 0 {
 		server.WriteTimeout = DefaultHTTPServer.WriteTimeout
@@ -144,6 +144,12 @@ func (gs *Server) Run(ctx context.Context) error {
 	gs.Server.Handler = WrapperHandler(gs.Now, gs.Server.Handler)
 	log.Printf("serving http on http://%s", gs.Addr().String())
 	return gs.Server.Serve(lis)
+}
+
+// Halt will attempt to gracefully shut down the server.
+func (gs *Server) Halt(ctx context.Context) error {
+	log.Printf("stopping serving http on http://%s...", gs.Addr().String())
+	return gs.Server.Shutdown(ctx)
 }
 
 // Addr will block until you have received an address for your server.

--- a/workers/httpsrv/httpsrv_test.go
+++ b/workers/httpsrv/httpsrv_test.go
@@ -2,7 +2,6 @@ package httpsrv_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -36,7 +35,7 @@ func Example() {
 	go httpsrv.New(&http.Server{
 		Handler:     handler,
 		ReadTimeout: 1 * time.Second,
-	}).Run(ctx, os.Stdout)
+	}).Run(ctx)
 }
 
 func TestHealthHandler(t *testing.T) {
@@ -86,7 +85,7 @@ func TestServer_Addr(t *testing.T) {
 			Handler: handler,
 		})
 		servers[i] = srv
-		go srv.Run(ctx, ioutil.Discard)
+		go srv.Run(ctx)
 	}
 	for _, srv := range servers {
 		test.NotEquals(t, ":0", srv.Addr().String())

--- a/workers/keybroker/README.md
+++ b/workers/keybroker/README.md
@@ -19,7 +19,7 @@ broker := keybroker.NewPublicRSA(&keybroker.Config{
 })
 
 // Run the broker
-go broker.Run(ctx, ioutil.Discard)
+go broker.Run(ctx)
 
 // Queue retrieval of new key
 broker.Renew()

--- a/workers/keybroker/broker.go
+++ b/workers/keybroker/broker.go
@@ -3,7 +3,7 @@ package keybroker
 import (
 	"context"
 	"fmt"
-	"io"
+	"log"
 	"time"
 )
 
@@ -70,8 +70,8 @@ func (b *broker) Close() {
 	b.ticker.Stop()
 }
 
-func (b *broker) Run(ctx context.Context, out io.Writer) {
-	fmt.Fprintf(out, "running %s broker checking for new key every %d second(s)\n", b.keyType, b.interval/time.Second)
+func (b *broker) Run(ctx context.Context) {
+	log.Printf("running %s broker checking for new key every %d second(s)\n", b.keyType, b.interval/time.Second)
 	b.running = true
 	defer func() { b.running = false }()
 	defer close(b.renew)
@@ -85,7 +85,7 @@ func (b *broker) Run(ctx context.Context, out io.Writer) {
 			case <-b.renew:
 				bts, err := b.source.Get(ctx)
 				if err != nil {
-					fmt.Fprintf(out, "%s broker interval error: %v\n", b.keyType, err)
+					log.Printf("%s broker interval error: %v\n", b.keyType, err)
 					b.Renew()
 				}
 				b.res <- bts

--- a/workers/keybroker/rsa.go
+++ b/workers/keybroker/rsa.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"fmt"
-	"io"
 	"log"
 	"math/big"
 
@@ -101,15 +100,15 @@ func (b *RSAPublicKeyBroker) Close() {
 }
 
 // Run will periodically try and the public key.
-func (b *RSAPublicKeyBroker) Run(ctx context.Context, out io.Writer) error {
-	go b.broker.Run(ctx, out)
+func (b *RSAPublicKeyBroker) Run(ctx context.Context) error {
+	go b.broker.Run(ctx)
 	select {
 	case res := <-b.broker.res:
 		key, err := jwt.ParseRSAPublicKeyFromPEM(res)
 		if err != nil {
 			return fmt.Errorf("cannot parse rsa public key: %v", err)
 		}
-		fmt.Fprintf(out, "rsa public key broker found new key of size %d\n", key.Size())
+		log.Printf("rsa public key broker found new key of size %d\n", key.Size())
 		b.key = key
 	case err := <-b.broker.err:
 		return err
@@ -154,15 +153,15 @@ func (b *RSAPrivateKeyBroker) Close() {
 }
 
 // Run will periodically try and the private key.
-func (b *RSAPrivateKeyBroker) Run(ctx context.Context, out io.Writer) error {
-	go b.broker.Run(ctx, out)
+func (b *RSAPrivateKeyBroker) Run(ctx context.Context) error {
+	go b.broker.Run(ctx)
 	select {
 	case res := <-b.broker.res:
 		key, err := jwt.ParseRSAPrivateKeyFromPEM(res)
 		if err != nil {
 			return fmt.Errorf("cannot parse rsa private key: %v", err)
 		}
-		fmt.Fprintf(out, "rsa private key broker found new key of size %d\n", key.Size())
+		log.Printf("rsa private key broker found new key of size %d\n", key.Size())
 		b.key = key
 	case err := <-b.broker.err:
 		return err

--- a/workers/keybroker/rsa_test.go
+++ b/workers/keybroker/rsa_test.go
@@ -2,7 +2,6 @@ package keybroker_test
 
 import (
 	"context"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -49,7 +48,7 @@ func Example() {
 	})
 
 	// Run the broker
-	go broker.Run(ctx, ioutil.Discard)
+	go broker.Run(ctx)
 
 	// Queue retrieval of new key
 	broker.Renew()
@@ -72,7 +71,7 @@ func TestRSAPublicKeyBroker_Run(t *testing.T) {
 			Source:   keybroker.StringSource(sourceString),
 			Interval: tick,
 		})
-		go b1.Run(ctx, ioutil.Discard)
+		go b1.Run(ctx)
 		defer b1.Close()
 
 		time.Sleep(10 * time.Millisecond)
@@ -84,7 +83,7 @@ func TestRSAPublicKeyBroker_Run(t *testing.T) {
 			Source:   &badSource{},
 			Interval: tick,
 		})
-		go b2.Run(ctx, ioutil.Discard)
+		go b2.Run(ctx)
 		defer b2.Close()
 
 		time.Sleep(10 * time.Millisecond)
@@ -101,7 +100,7 @@ func TestRSAPublicKeyBroker_Check(t *testing.T) {
 		Interval: tick,
 	})
 
-	go b1.Run(ctx, ioutil.Discard)
+	go b1.Run(ctx)
 	time.Sleep(10 * time.Millisecond)
 
 	t.Run("good source, started", func(t *testing.T) {
@@ -123,7 +122,7 @@ func TestRSAPublicKeyBroker_Check(t *testing.T) {
 		Source:   &badSource{},
 		Interval: tick,
 	})
-	go b2.Run(ctx, ioutil.Discard)
+	go b2.Run(ctx)
 	time.Sleep(10 * time.Millisecond)
 
 	t.Run("good source, started", func(t *testing.T) {
@@ -146,7 +145,7 @@ func TestRSAPrivateKeyBroker_Run(t *testing.T) {
 			Source:   keybroker.StringSource(privSourceString),
 			Interval: tick,
 		})
-		go b1.Run(ctx, ioutil.Discard)
+		go b1.Run(ctx)
 		defer b1.Close()
 
 		time.Sleep(10 * time.Millisecond)
@@ -158,7 +157,7 @@ func TestRSAPrivateKeyBroker_Run(t *testing.T) {
 			Source:   &badSource{},
 			Interval: tick,
 		})
-		go b2.Run(ctx, ioutil.Discard)
+		go b2.Run(ctx)
 		defer b2.Close()
 
 		time.Sleep(10 * time.Millisecond)
@@ -175,7 +174,7 @@ func TestRSAPrivateKeyBroker_Check(t *testing.T) {
 		Interval: tick,
 	})
 
-	go b1.Run(ctx, ioutil.Discard)
+	go b1.Run(ctx)
 	time.Sleep(10 * time.Millisecond)
 
 	t.Run("good source, started", func(t *testing.T) {
@@ -197,7 +196,7 @@ func TestRSAPrivateKeyBroker_Check(t *testing.T) {
 		Source:   &badSource{},
 		Interval: tick,
 	})
-	go b2.Run(ctx, ioutil.Discard)
+	go b2.Run(ctx)
 	time.Sleep(10 * time.Millisecond)
 
 	t.Run("good source, started", func(t *testing.T) {

--- a/workers/metricsrv/README.md
+++ b/workers/metricsrv/README.md
@@ -18,5 +18,5 @@ srv := metricsrv.New(&metricsrv.Config{
     },
     Path: "/metrics",
 })
-srv.Run(ctx, ioutil.Discard)
+srv.Run(ctx)
 ```

--- a/workers/metricsrv/metricsrv.go
+++ b/workers/metricsrv/metricsrv.go
@@ -3,8 +3,7 @@ package metricsrv
 
 import (
 	"context"
-	"fmt"
-	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -79,7 +78,7 @@ func (s *Server) Addr() *net.TCPAddr {
 }
 
 // Run will start the metrics server.
-func (s *Server) Run(ctx context.Context, out io.Writer) error {
+func (s *Server) Run(ctx context.Context) error {
 	lis, err := net.Listen("tcp", s.Server.Addr)
 	if err != nil {
 		return err
@@ -89,6 +88,6 @@ func (s *Server) Run(ctx context.Context, out io.Writer) error {
 	mux := http.NewServeMux()
 	mux.Handle(s.Path, promhttp.Handler())
 	s.Server.Handler = mux
-	fmt.Fprintf(out, "serving prometheus metrics over http on http://%s%s", s.Addr().String(), s.Path)
+	log.Printf("serving prometheus metrics over http on http://%s%s", s.Addr().String(), s.Path)
 	return s.Server.Serve(lis)
 }

--- a/workers/metricsrv/metricsrv.go
+++ b/workers/metricsrv/metricsrv.go
@@ -91,3 +91,9 @@ func (s *Server) Run(ctx context.Context) error {
 	log.Printf("serving prometheus metrics over http on http://%s%s", s.Addr().String(), s.Path)
 	return s.Server.Serve(lis)
 }
+
+// Halt will attempt to gracefully shut down the server.
+func (s *Server) Halt(ctx context.Context) error {
+	log.Printf("stopping serving prometheus metrics over http on http://%s...", s.Addr().String())
+	return s.Server.Shutdown(ctx)
+}

--- a/workers/metricsrv/metricsrv_test.go
+++ b/workers/metricsrv/metricsrv_test.go
@@ -2,7 +2,6 @@ package metricsrv_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -23,7 +22,7 @@ func ExampleServer_Run() {
 		},
 		Path: "/metrics",
 	})
-	srv.Run(ctx, ioutil.Discard)
+	srv.Run(ctx)
 }
 
 func TestNew(t *testing.T) {
@@ -55,7 +54,7 @@ func TestServer_Addr(t *testing.T) {
 			},
 		})
 		servers[i] = srv
-		go srv.Run(ctx, ioutil.Discard)
+		go srv.Run(ctx)
 	}
 	for _, srv := range servers {
 		test.NotEquals(t, ":0", srv.Addr().String())

--- a/workers/readysrv/README.md
+++ b/workers/readysrv/README.md
@@ -4,13 +4,13 @@ The package `core/workers/readysrv` is used to provide readiness checks for a se
 ## Configuration
 The readiness server can be configured through the environment to match setup in the infrastructure.
 
-- `READINESS_INTERFACE` default: `:3674`
+- `READINESS_ADDR` default: `0.0.0.0:3674`
 - `READINESS_PATH` default: `/ready`
 
 ## Examples
 
 ```go
-srv := readysrv.New(readysrv.Checks{
+srv := readysrv.New(nil, readysrv.Checks{
     "google": readysrv.CheckerFunc(func() ([]string, bool) {
         if _, err := http.Get("https://google.com"); err != nil {
             return []string{err.Error()}, false
@@ -18,5 +18,5 @@ srv := readysrv.New(readysrv.Checks{
         return []string{"google can be accessed"}, true
     }),
 })
-srv.Run(ctx, ioutil.Discard)
+srv.Run(ctx)
 ```

--- a/workers/readysrv/readysrv.go
+++ b/workers/readysrv/readysrv.go
@@ -4,8 +4,7 @@ package readysrv
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"io"
+	"log"
 	"net/http"
 	"os"
 )
@@ -35,7 +34,7 @@ type Server struct {
 }
 
 // Run will start the metrics server.
-func (s *Server) Run(ctx context.Context, out io.Writer) error {
+func (s *Server) Run(ctx context.Context) error {
 	addr := os.Getenv("READINESS_INTERFACE")
 	if addr == "" {
 		addr = DefaultInterface
@@ -44,7 +43,7 @@ func (s *Server) Run(ctx context.Context, out io.Writer) error {
 	if path == "" {
 		path = DefaultPath
 	}
-	fmt.Fprintf(out, "serving readiness checks server over http on http://%s%s", s.Interface, s.Path)
+	log.Printf("serving readiness checks server over http on http://%s%s", s.Interface, s.Path)
 	http.Handle(path, CheckHandler(s.Checks))
 	return http.ListenAndServe(addr, nil)
 

--- a/workers/readysrv/readysrv.go
+++ b/workers/readysrv/readysrv.go
@@ -5,48 +5,100 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"net"
 	"net/http"
 	"os"
+	"path"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
-	// DefaultInterface is the port that we listen to the prometheus path on by default.
-	DefaultInterface = "0.0.0.0:3674"
+	// DefaultAddr is the port that we listen to the prometheus path on by default.
+	DefaultAddr = "0.0.0.0:3674"
 
 	// DefaultPath is the path where we expose prometheus by default.
 	DefaultPath = "/ready"
 )
 
+// Config represents the configuration for the metrics server.
+type Config struct {
+	Path   string
+	Server *http.Server
+}
+
 // New creates a new default metrics server.
-func New(checks Checks) *Server {
+func New(config *Config, checks Checks) *Server {
+	if config == nil {
+		config = &Config{}
+	}
+	if path := os.Getenv("READINESS_PATH"); path != "" && config.Path == "" {
+		config.Path = path
+	}
+	if config.Path == "" {
+		config.Path = DefaultPath
+	}
+	if config.Server == nil {
+		config.Server = &http.Server{}
+	}
+	if addr := os.Getenv("READINESS_ADDR"); addr != "" && config.Server.Addr == "" {
+		config.Server.Addr = addr
+	}
+	if config.Server.Addr == "" {
+		config.Server.Addr = DefaultAddr
+	}
+	config.Server.Handler = CheckHandler(checks)
 	return &Server{
-		Interface: DefaultInterface,
-		Path:      DefaultPath,
-		Checks:    checks,
+		Checks: checks,
+		Server: config.Server,
+		Path:   path.Join("/", config.Path),
+		addrC:  make(chan *net.TCPAddr, 1),
 	}
 }
 
 // Server defines a readiness server.
 type Server struct {
-	Interface string
-	Path      string
-	Checks    Checks
+	Path    string
+	Checks  Checks
+	Server  *http.Server
+	addrC   chan *net.TCPAddr
+	tcpAddr *net.TCPAddr
+}
+
+// Addr will block until you have received an address for your server.
+func (s *Server) Addr() *net.TCPAddr {
+	if s.tcpAddr != nil {
+		return s.tcpAddr
+	}
+	t := time.NewTimer(5 * time.Second)
+	select {
+	case addr := <-s.addrC:
+		s.tcpAddr = addr
+	case <-t.C:
+		return &net.TCPAddr{}
+	}
+	return s.tcpAddr
 }
 
 // Run will start the metrics server.
 func (s *Server) Run(ctx context.Context) error {
-	addr := os.Getenv("READINESS_INTERFACE")
-	if addr == "" {
-		addr = DefaultInterface
+	lis, err := net.Listen("tcp", s.Server.Addr)
+	if err != nil {
+		return err
 	}
-	path := os.Getenv("READINESS_PATH")
-	if path == "" {
-		path = DefaultPath
-	}
-	log.Printf("serving readiness checks server over http on http://%s%s", s.Interface, s.Path)
-	http.Handle(path, CheckHandler(s.Checks))
-	return http.ListenAndServe(addr, nil)
+	s.addrC <- lis.Addr().(*net.TCPAddr)
+	mux := http.NewServeMux()
+	mux.Handle(s.Path, promhttp.Handler())
+	s.Server.Handler = mux
+	log.Printf("serving readiness checks server over http on http://%s%s", s.Addr(), s.Path)
+	return s.Server.Serve(lis)
+}
 
+// Halt will attempt to gracefully shut down the server.
+func (s *Server) Halt(ctx context.Context) error {
+	log.Printf("stopping readiness checks server over http on http://%s...", s.Addr().String())
+	return s.Server.Shutdown(ctx)
 }
 
 // CheckHandler provides a function for providing health checks over http.

--- a/workers/readysrv/readysrv_test.go
+++ b/workers/readysrv/readysrv_test.go
@@ -2,7 +2,6 @@ package readysrv_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,7 +23,7 @@ func Example() {
 			return []string{"google can be accessed"}, true
 		}),
 	})
-	srv.Run(ctx, ioutil.Discard)
+	srv.Run(ctx)
 }
 
 func TestCheckerFunc(t *testing.T) {

--- a/workers/readysrv/readysrv_test.go
+++ b/workers/readysrv/readysrv_test.go
@@ -15,7 +15,7 @@ var (
 )
 
 func Example() {
-	srv := readysrv.New(readysrv.Checks{
+	srv := readysrv.New(nil, readysrv.Checks{
 		"google": readysrv.CheckerFunc(func() ([]string, bool) {
 			if _, err := http.Get("https://google.com"); err != nil {
 				return []string{err.Error()}, false


### PR DESCRIPTION
## New service worker API
Before we required both a `context.Context` and an `io.Writer` in the worker Run method signature. With this change, this has been simplified, and we no longer need to pass a `io.Writer` as we communicate directly with the go logger.

Now the worker interface follows two very behaviours: running and halting.

```go
// Runner represents the behaviour for running a service worker.
type Runner interface {
	// Run should run start processing the worker and be a blocking operation.
	Run(context.Context) error
}

// Halter represents the behaviour for stopping a service worker.
type Halter interface {
	// Halt should tell the worker to stop doing work.
	Halt(context.Context) error
}

// Worker represents the behaviour for a service worker.
type Worker interface {
	Runner
	Halter
}
```

## Graceful termination
The purpose of this is to allow graceful termination of subsequent workers and wait for them to complete their work before the Go process is killed. As a side effect, we’re able to also gracefully shut down adjacent workers once a worker fails within the same grace period.