### PR TITLE
Pagination underflow protection

### DIFF
--- a/pagination/pagination.go
+++ b/pagination/pagination.go
@@ -23,7 +23,11 @@ func (r Request) Metadata() metadata.MD {
 
 // Offset calculates the offset from the provided pagination request.
 func (r Request) Offset() uint64 {
-	return (r.Page - 1) * r.PerPage
+	p := r.Page
+	if p < 1 {
+		p = 1
+	}
+	return (p - 1) * r.PerPage
 }
 
 // Response manages pagination of a data set.

--- a/pagination/pagination_test.go
+++ b/pagination/pagination_test.go
@@ -60,6 +60,14 @@ func TestMakeResponse(t *testing.T) {
 			total:   100,
 			expErr:  pagination.ErrCalculateOffset,
 		},
+		{
+			name:             "Page 0 must not cause underflow",
+			perPage:          10,
+			page:             0,
+			total:            100,
+			expectedOffset:   0,
+			expectedLastPage: 10,
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
the current `Offset()` method in the pagination package has a risk to underflow when `Page` is set to 0. For example:

if `Page` is set to 0, and `PerPage` is set to 10, the currently calculated offset would be `18446744073709551606`, which is of course incorrect.

Adding a guard check here prevents this from happening.