### PR TITLE
automatically handle CORS preflight requests, globally

### DIFF
--- a/test/assert_test.go
+++ b/test/assert_test.go
@@ -38,7 +38,7 @@ func TestEquals(t *testing.T) {
 		},
 	}
 	for n, tC := range testCases {
-		t.Run(string(n), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
 			test.Equals(t, tC.expected, tC.actual)
 		})
 	}
@@ -75,7 +75,7 @@ func TestNotEquals(t *testing.T) {
 		},
 	}
 	for n, tC := range testCases {
-		t.Run(string(n), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
 			test.NotEquals(t, tC.expected, tC.actual)
 		})
 	}

--- a/workers/httpsrv/httpsrv.go
+++ b/workers/httpsrv/httpsrv.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -39,16 +40,37 @@ var (
 		IdleTimeout:       5 * time.Second,
 		ReadHeaderTimeout: 1 * time.Second,
 	}
+
+	DefaultCORS = CORS{
+		// Use broad defaults.
+		// Origin: "*" is safe, see: https://fetch.spec.whatwg.org/#basic-safe-cors-protocol-setup
+		AllowOrigin: "*",
+		AllowHeaders: []string{
+			"Authorization",
+			"Origin",
+			"Accept",
+			"Content-Type",
+			"X-Requested-With",
+		},
+		AllowMethods: []string{
+			http.MethodGet,
+			http.MethodHead,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+	}
 )
 
 // WrapperHandler returns the wrapper handler for the http server.
-func WrapperHandler(now func() time.Time, next http.Handler) http.HandlerFunc {
+func WrapperHandler(now func() time.Time, cors CORS, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		switch r.RequestURI {
-		case "/healthz":
+		switch {
+		case r.RequestURI == "/healthz":
 			HealthHandler(now)(w, r)
 		default:
-			next.ServeHTTP(w, r)
+			CORSHandler(cors, next)(w, r)
 		}
 	}
 }
@@ -78,6 +100,31 @@ func HealthHandler(now func() time.Time) http.HandlerFunc {
 		}
 		res.WriteTo(w)
 	}
+}
+
+// CORSHandler updates headers on CORS preflight requests and actual CORS requests.
+func CORSHandler(c CORS, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			handlePreflight(c, w, r)
+		} else {
+			// This is an actual request. If CORS, it will require this header, if not, no harm done.
+			w.Header().Set("Access-Control-Allow-Origin", c.AllowOrigin)
+			next.ServeHTTP(w, r)
+		}
+	}
+}
+
+func handlePreflight(c CORS, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodOptions {
+		log.Printf("CORS pre-flight aborted: %s!=OPTIONS", r.Method)
+		return
+	}
+	headers := w.Header()
+	headers.Set("Access-Control-Allow-Origin", c.AllowOrigin)
+	headers.Set("Access-Control-Allow-Headers", strings.Join(c.AllowHeaders, ", "))
+	headers.Set("Access-Control-Allow-Methods", strings.Join(c.AllowMethods, ", "))
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // NewDefault returns a http server
@@ -115,12 +162,20 @@ func New(server *http.Server) *Server {
 		Server: server,
 		Now:    time.Now,
 		addrC:  make(chan *net.TCPAddr, 1),
+		CORS:   DefaultCORS,
 	}
+}
+
+type CORS struct {
+	AllowOrigin  string
+	AllowHeaders []string
+	AllowMethods []string
 }
 
 // Server represents a collection of functions for starting and running an RPC server.
 type Server struct {
 	Server  *http.Server
+	CORS    CORS
 	Now     func() time.Time
 	addrC   chan *net.TCPAddr
 	tcpAddr *net.TCPAddr
@@ -139,7 +194,7 @@ func (gs *Server) Run(_ context.Context) error {
 		return fmt.Errorf("http server needs a handler")
 	}
 
-	gs.Server.Handler = WrapperHandler(gs.Now, gs.Server.Handler)
+	gs.Server.Handler = WrapperHandler(gs.Now, gs.CORS, gs.Server.Handler)
 	log.Printf("serving http on http://%s", gs.Addr().String())
 	return gs.Server.Serve(lis)
 }

--- a/workers/httpsrv/httpsrv.go
+++ b/workers/httpsrv/httpsrv.go
@@ -41,6 +41,7 @@ var (
 		ReadHeaderTimeout: 1 * time.Second,
 	}
 
+	// DefaultCORS contains the default CORS settings used when starting an httpsrv.Server
 	DefaultCORS = CORS{
 		// Use broad defaults.
 		// Origin: "*" is safe, see: https://fetch.spec.whatwg.org/#basic-safe-cors-protocol-setup
@@ -166,6 +167,7 @@ func New(server *http.Server) *Server {
 	}
 }
 
+// CORS defines a struct which allows configuring the CORS settings for httpsrv.Server
 type CORS struct {
 	AllowOrigin  string
 	AllowHeaders []string


### PR DESCRIPTION
This change makes is so that the server, when run, will automatically
accept and handle all CORS requests. The added CORS handler responds to
CORS preflight requests with the needed headers updated to allow CORS
requests. When running the server the CORS handler is added such that
all requests with the method OPTIONS will be treated as CORS preflight
requests.