### PR TITLE
clarify logging when resolving key source during startup

### DIFF
--- a/test/assert_test.go
+++ b/test/assert_test.go
@@ -38,7 +38,7 @@ func TestEquals(t *testing.T) {
 		},
 	}
 	for n, tC := range testCases {
-		t.Run(string(n), func(t *testing.T) {
+		t.Run(fmt.Sprint(n), func(t *testing.T) {
 			test.Equals(t, tC.expected, tC.actual)
 		})
 	}
@@ -75,7 +75,7 @@ func TestNotEquals(t *testing.T) {
 		},
 	}
 	for n, tC := range testCases {
-		t.Run(string(n), func(t *testing.T) {
+		t.Run(fmt.Sprint(n), func(t *testing.T) {
 			test.NotEquals(t, tC.expected, tC.actual)
 		})
 	}

--- a/workers/keybroker/source.go
+++ b/workers/keybroker/source.go
@@ -24,9 +24,10 @@ func (sources Sources) Get(ctx context.Context) ([]byte, error) {
 	for _, source := range sources {
 		bts, err := source.Get(ctx)
 		if err == nil {
+			log.Printf("keybroker successfully resolved source %q\n", source)
 			return bts, nil
 		}
-		log.Printf("could not resolve source %s: %v: skipping...\n", source, err)
+		log.Printf("keybroker could not resolve source %q: %v: skipping...\n", source, err)
 	}
 	return nil, ErrNoSourcesResolved{
 		N: len(sources),


### PR DESCRIPTION
The current log messages are not clear as to whether an error has
occurred, or whether the unresolved source is a normal step. After
failing a source or more, there is no clear indication of whether
another resolved, and which source that was.

This change modifies the failure message for clarity and adds a log
message showing which source was resolved.