### PR TITLE
Use promauto for metrics middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 # ![Donguri by Cerys Evans](https://res.cloudinary.com/lush/image/upload/c_scale,w_60/v1568812743/github/core/donguri_wink_cropped.jpg) Core (Go)
 A collection of packages for building a Go microservice on the LUSH platform.
 
-
 ## Quick start
 Below there's an example for how to get running quickly with a service using the LUSHDigital core package.
 
@@ -17,27 +16,34 @@ import (
 	"time"
 
 	"github.com/LUSHDigital/core"
+	"github.com/LUSHDigital/core/middleware/metricsmw"
 	"github.com/LUSHDigital/core/workers/httpsrv"
 	"github.com/LUSHDigital/core/workers/keybroker"
 	"github.com/LUSHDigital/core/workers/metricsrv"
 	"github.com/LUSHDigital/core/workers/readysrv"
 )
 
-func main() {
-	service := core.NewService("example", "service")
+var service = &core.Service{
+	Name:    "example",
+	Type:    "service",
+	Version: "1.0.0",
+}
 
+func main() {
 	metrics := metricsrv.New(nil)
 	broker := keybroker.NewPublicRSA(nil)
 	readiness := readysrv.New(nil, readysrv.Checks{
-		"rsa_key": broker,
+		"public_rsa_key": broker,
 	})
+
+	handler := metricsmw.MeasureRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("hello world"))
+	}))
 
 	server := httpsrv.New(&http.Server{
 		ReadTimeout: 10 * time.Second,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(200)
-			w.Write([]byte("hello world"))
-		}),
+		Handler:     handler,
 	})
 
 	service.MustRun(context.Background(),
@@ -47,10 +53,11 @@ func main() {
 		readiness,
 	)
 }
+
 ```
 
 ## Documentation
-Documentation and examples are provided in README files in each pacakge.
+Documentation and examples are provided in README files in each package.
 
 ### Core Concepts
 These packages contain functionality for the core concepts of our services.
@@ -89,16 +96,16 @@ There are a few libraries that can be used in conjunction with the core library 
 - [LUSHDigital/core-lush](https://github.com/LUSHDigital/core-lush#core-lush-go): Packages specific to the LUSH platform.
 
 ## Tools
-There are a few tools that can be used with projects that use the core libary.
+There are a few tools that can be used with projects that use the core library.
 
 - [LUSHDigital/jwtl](https://github.com/LUSHDigital/jwtl#jwtl-json-web-token-command-line-tool): A command line tool to help generating JWTs during development.
-- [LUSHDigital/core-mage](https://github.com/LUSHDigital/core-mage): A library for the [mage build tool](https://magefile.org/) including convenient build targets used in conjunction with a projcet using this core library.
+- [LUSHDigital/core-mage](https://github.com/LUSHDigital/core-mage): A library for the [mage build tool](https://magefile.org/) including convenient build targets used in conjunction with a project using this core library.
 
 ## Recommended Libraries
 Some libraries have been designed to work together with the core library and some are even dependencies.
 Consider using these if you need extended functionality for certain things.
 
-- [LUSHDigital/scan](https://github.com/LUSHDigital/scan): Scan database/sql rows directly to structs, slices, and primitive types, originally forked from github.com/blockloop/scan
+- [LUSHDigital/scan](https://github.com/LUSHDigital/scan): Scan database/sql rows directly to a struct, slice, or primitive any type. Originally forked from github.com/blockloop/scan
 - [LUSHDigital/uuid](https://github.com/LUSHDigital/uuid): A UUID package originally forked from github.com/gofrs/uuid & github.com/satori/go.uuid
 - [LUSHDigital/spew](https://github.com/LUSHDigital/spew): A pretty-printer package originally forked from github.com/davecgh/go-spew/spew
 

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/LUSHDigital/core"
+	"github.com/LUSHDigital/core/middleware/metricsmw"
 	"github.com/LUSHDigital/core/workers/httpsrv"
 	"github.com/LUSHDigital/core/workers/keybroker"
 	"github.com/LUSHDigital/core/workers/metricsrv"
@@ -25,12 +26,14 @@ func main() {
 		"public_rsa_key": broker,
 	})
 
+	handler := metricsmw.MeasureRequests(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("hello world"))
+	}))
+
 	server := httpsrv.New(&http.Server{
 		ReadTimeout: 10 * time.Second,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(200)
-			w.Write([]byte("hello world"))
-		}),
+		Handler:     handler,
 	})
 
 	service.MustRun(context.Background(),

--- a/middleware/metricsmw/http.go
+++ b/middleware/metricsmw/http.go
@@ -45,14 +45,14 @@ type recorder struct {
 
 func (w *recorder) WriteHeader(status int) {
 	w.status = status
-	w.ResponseWriter.WriteHeader(status)
+	w.WriteHeader(status)
 }
 
 func (w *recorder) Write(b []byte) (int, error) {
 	if w.status == 0 {
 		w.status = 200
 	}
-	n, err := w.ResponseWriter.Write(b)
+	n, err := w.Write(b)
 	w.length += n
 	return n, err
 }
@@ -91,7 +91,9 @@ func MeasureRequests(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var (
 			now = time.Now()
-			rec = &recorder{}
+			rec = &recorder{
+				ResponseWriter: w,
+			}
 		)
 
 		// Pass the request through to the handler.

--- a/middleware/metricsmw/http.go
+++ b/middleware/metricsmw/http.go
@@ -45,14 +45,14 @@ type recorder struct {
 
 func (w *recorder) WriteHeader(status int) {
 	w.status = status
-	w.WriteHeader(status)
+	w.ResponseWriter.WriteHeader(status)
 }
 
 func (w *recorder) Write(b []byte) (int, error) {
 	if w.status == 0 {
 		w.status = 200
 	}
-	n, err := w.Write(b)
+	n, err := w.ResponseWriter.Write(b)
 	w.length += n
 	return n, err
 }

--- a/middleware/metricsmw/http.go
+++ b/middleware/metricsmw/http.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-
 	// RequestDurationHistogram measures the duration in seconds for requests.
-	RequestDurationHistogram = prometheus.NewHistogramVec(
+	RequestDurationHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "http_request_duration_seconds",
 			Help: "Duration in seconds of each request",
@@ -21,7 +21,7 @@ var (
 	)
 
 	// ResponseSizeHistogram measures the size in bytes for responses.
-	ResponseSizeHistogram = prometheus.NewHistogramVec(
+	ResponseSizeHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "http_response_byte_size",
 			Help: "Size in bytes of each response",
@@ -30,6 +30,7 @@ var (
 	)
 
 	// All represents a combination of all HTTP metric collectors.
+	// TODO: Remove once we move to v1.0 since we no longer need to register the collectors manually.
 	All = []prometheus.Collector{
 		RequestDurationHistogram,
 		ResponseSizeHistogram,
@@ -57,8 +58,10 @@ func (w *recorder) Write(b []byte) (int, error) {
 }
 
 // Register registers all the metric collectors with prometheus.
+// DEPRECATED: metricsmw.Register() does not need to be called since registering of metrics now happens automatically.
+// TODO: Remove once we move to v1.0 since we no longer need to register the collectors manually.
 func Register() {
-	prometheus.MustRegister(All...)
+	log.Println("DEPRECATED: metricsmw.Register() does not need to be called since registering of metrics now happens automatically")
 }
 
 // MiddlewareFunc represents a middleware func for use with gorilla mux.

--- a/test/assert_test.go
+++ b/test/assert_test.go
@@ -38,7 +38,7 @@ func TestEquals(t *testing.T) {
 		},
 	}
 	for n, tC := range testCases {
-		t.Run(string(n), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
 			test.Equals(t, tC.expected, tC.actual)
 		})
 	}
@@ -75,7 +75,7 @@ func TestNotEquals(t *testing.T) {
 		},
 	}
 	for n, tC := range testCases {
-		t.Run(string(n), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%d", n), func(t *testing.T) {
 			test.NotEquals(t, tC.expected, tC.actual)
 		})
 	}


### PR DESCRIPTION
- Make sure the promauto is used to automatically register the middleware with prometheus
- Deprecate the manual step for registering HTTP metrics
- Change the core example documentation to include the use of metrics middleware for HTTP
- Fix several spelling mistakes in documentation