### PR TITLE
Feat/remove path from metrics

### DIFF
--- a/middleware/metricsmw/README.md
+++ b/middleware/metricsmw/README.md
@@ -28,7 +28,7 @@ Using gorilla mux.
 
 ```go
 r := mux.NewRouter()
-r.Use(metrics.MeasureRequestsMiddleware)
+r.Use(mux.MiddlewareFunc(metrics.MeasureRequestsMiddleware))
 ```
 
 Using standard net/http library.

--- a/middleware/metricsmw/http.go
+++ b/middleware/metricsmw/http.go
@@ -17,7 +17,7 @@ var (
 			Name: "http_request_duration_seconds",
 			Help: "Duration in seconds of each request",
 		},
-		[]string{"method", "code", "path"},
+		[]string{"method", "code"},
 	)
 
 	// ResponseSizeHistogram measures the size in bytes for responses.
@@ -26,7 +26,7 @@ var (
 			Name: "http_response_byte_size",
 			Help: "Size in bytes of each response",
 		},
-		[]string{"method", "code", "path"},
+		[]string{"method", "code"},
 	)
 
 	// All represents a combination of all HTTP metric collectors.
@@ -103,7 +103,6 @@ func MeasureRequests(next http.HandlerFunc) http.HandlerFunc {
 		labels := prometheus.Labels{
 			"method": r.Method,
 			"code":   strconv.Itoa(rec.status),
-			"path":   r.RequestURI,
 		}
 
 		if rsh, err := ResponseSizeHistogram.GetMetricWith(labels); err != nil {


### PR DESCRIPTION
Without importing another package it is currently not implemented to record the path of a request in a way that does not create an unbounded set of possible metrics.

Until this is fixed we should removed the path from the collected metrics to avoid flooding metrics servers. 