### PR TITLE
feat:adjust histogram buckets

### DIFF
--- a/middleware/metricsmw/README.md
+++ b/middleware/metricsmw/README.md
@@ -38,3 +38,8 @@ http.Handle("/check", metrics.MeasureRequests(func(w http.ResponseWriter, r *htt
     w.WriteHeader(200)
 }))
 ```
+
+### Time series buckets
+The collection of histogram metrics must put data into predefined buckets.
+These have been set at: `0.2, 0.4, 0.6, 0.8, 1.0, 1.5, 2.0, 5.0, 10.0, 15.0` seconds.
+more information can be found here: [Prometheus Documentation](https://prometheus.io/docs/practices/histograms/#errors-of-quantile-estimation)

--- a/middleware/metricsmw/grpc.go
+++ b/middleware/metricsmw/grpc.go
@@ -22,6 +22,8 @@ var StreamClientInterceptor = grpcprometheus.StreamClientInterceptor
 var UnaryClientInterceptor = grpcprometheus.UnaryClientInterceptor
 
 func init() {
+	// buckets are the values in seconds that represent the upper limit of the histogram buckets.
+	// These are set to focus the collection around 1 second whilst providing scope for large values.
 	buckets := []float64{0.2,0.4,0.6,0.8,1,1.5,2,5,10,15}
 	grpcprometheus.EnableHandlingTimeHistogram(grpcprometheus.WithHistogramBuckets(buckets))
 }

--- a/middleware/metricsmw/grpc.go
+++ b/middleware/metricsmw/grpc.go
@@ -22,5 +22,6 @@ var StreamClientInterceptor = grpcprometheus.StreamClientInterceptor
 var UnaryClientInterceptor = grpcprometheus.UnaryClientInterceptor
 
 func init() {
-	grpcprometheus.EnableHandlingTimeHistogram()
+	buckets := []float64{0.2,0.4,0.6,0.8,1,1.5,2,5,10,15}
+	grpcprometheus.EnableHandlingTimeHistogram(grpcprometheus.WithHistogramBuckets(buckets))
 }


### PR DESCRIPTION
The default histograms buckets are not providing the level of detail we need to track our services. We should change them to more suitable values.